### PR TITLE
Bug Fix: When port with added node in the cluster crashes PlantUML

### DIFF
--- a/src/net/sourceforge/plantuml/svek/Cluster.java
+++ b/src/net/sourceforge/plantuml/svek/Cluster.java
@@ -835,12 +835,12 @@ public class Cluster implements Moveable {
 		printCluster1(sb, lines, stringBounder);
 
 		final Node added = printCluster2(sb, lines, stringBounder, dotMode, graphvizVersion, type);
-		if (entityPositionsExceptNormal.size() > 0 && added == null) {
+		if (entityPositionsExceptNormal.size() > 0) {
 			if (hasPort()) {
 				sb.append(empty() + " [shape=rect,width=.01,height=.01,label=");
 				sb.append(label);
 				sb.append("];");
-			} else {
+			} else if (added == null) {
 				sb.append(empty() + " [shape=point,width=.01,label=\"\"];");
 			}
 			SvekUtils.println(sb);


### PR DESCRIPTION
The following plantuml code causes IllegalStateException

@startuml

rectangle "rv" { 
	port "hitchReceiver" 
	rectangle "cabin"
}

@enduml

Because a label for the port is missing.