### PR TITLE
Cluster Empty node is not properly located when thereALinkFromOrToGroup2 is enabled

### DIFF
--- a/src/net/sourceforge/plantuml/svek/Cluster.java
+++ b/src/net/sourceforge/plantuml/svek/Cluster.java
@@ -873,7 +873,11 @@ public class Cluster implements Moveable {
 	}
 
 	private String empty() {
-		return "empty" + color;
+		// return "empty" + color;
+        // We use the same node with one for thereALinkFromOrToGroup2 as an empty
+        // because we cannot put a new node in the nested inside of the cluster
+        // if thereALinkFromOrToGroup2 is enabled.
+        return getSpecialPointId(group);
 	}
 
 	public boolean isLabel() {


### PR DESCRIPTION
In the following code, the generalization line by Eid17--|>Eid10 is not properly drawn.

@startuml

rectangle "Vehicle" as Eid1{
	port "hitchReceiver: Port" as Eid5
}
rectangle "RV" as Eid8 {
	rectangle "cabin: Cabin" as Eid10 
}

rectangle "rv: RV" as Eid14 {
	rectangle "cabin: Cabin" as Eid17 {
		port "mount: Port" as Eid18  
	}
}

Eid17--|>Eid10
Eid5 -- Eid18

@enduml